### PR TITLE
🎨 Palette: Contact form character counter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-02-14 - Interactive Navigation Feedback and Component Extensibility
 **Learning:** Mobile menu toggles that don't change their icon (e.g., staying as a hamburger when open) fail to provide immediate visual confirmation of the menu state. Additionally, internal UI components like 'MagneticButton' must support attribute spreading to allow developers to inject critical accessibility attributes (like aria-label) without modifying the base component.
 **Action:** Ensure all toggle interactions have distinct visual states (icons/colors) and ensure all base UI components spread '...rest' props to their root interactive element.
+
+## 2026-02-14 - Real-time Character Constraints and Threshold Feedback
+**Learning:** For fields with large character limits (e.g., 5,000 chars), users need real-time feedback to prevent "silent" truncation on submission. Combining `aria-describedby` for the count with a visual threshold indicator (changing color at 90% capacity) provides both proactive guidance and accessibility.
+**Action:** Implement real-time counters for constrained textareas, using `aria-live="polite"` for the counter and the brand's `accent` color for threshold warnings.

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -97,7 +97,8 @@ const messagePlaceholder =
                    Message <span class="text-accent">*</span>
                  </span>
                </label>
-               <textarea class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none" id="message" name="message" placeholder={messagePlaceholder} required aria-required="true"></textarea>
+               <textarea class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none" id="message" name="message" placeholder={messagePlaceholder} required aria-required="true" maxlength="5000" aria-describedby="message-counter"></textarea>
+               <div id="message-counter" class="text-xs opacity-50 mt-2 text-right transition-colors duration-300" aria-live="polite">0 / 5000</div>
             </div>
 
             <div class="group">
@@ -323,9 +324,23 @@ const messagePlaceholder =
     const statusBox = document.getElementById('form-status');
     const subjectSelect = form.querySelector('#subject');
     const messageInput = form.querySelector('#message');
+    const messageCounter = document.getElementById('message-counter');
     const fileInput = document.querySelector('#attachment');
     const fileNameDisplay = document.getElementById('file-name');
     const roleFromQuery = form.dataset.role?.trim() ?? '';
+
+    const updateCounter = () => {
+      if (!(messageInput instanceof HTMLTextAreaElement) || !(messageCounter instanceof HTMLElement)) return;
+      const count = messageInput.value.length;
+      messageCounter.textContent = `${count} / 5000`;
+      if (count >= 4500) {
+        messageCounter.classList.add('text-accent');
+        messageCounter.classList.remove('opacity-50');
+      } else {
+        messageCounter.classList.remove('text-accent');
+        messageCounter.classList.add('opacity-50');
+      }
+    };
 
     const prefillCareerApplicationMessage = () => {
       if (!(subjectSelect instanceof HTMLSelectElement) || !(messageInput instanceof HTMLTextAreaElement)) return;
@@ -336,11 +351,18 @@ const messagePlaceholder =
         'Current location:\n' +
         'Availability:\n' +
         'CV/Portfolio link:\n';
+      updateCounter();
     };
 
     prefillCareerApplicationMessage();
+    updateCounter();
+
     if (subjectSelect instanceof HTMLSelectElement) {
       subjectSelect.addEventListener('change', prefillCareerApplicationMessage);
+    }
+
+    if (messageInput instanceof HTMLTextAreaElement) {
+      messageInput.addEventListener('input', updateCounter);
     }
 
     // Display selected file name
@@ -411,6 +433,7 @@ const messagePlaceholder =
 
         setStatus('success', result.message || 'Your message has been sent.');
         form.reset();
+        updateCounter();
         if (fileNameDisplay instanceof HTMLElement) fileNameDisplay.classList.add('hidden');
         if (subjectSelect instanceof HTMLSelectElement && selected) {
           subjectSelect.value = selected;


### PR DESCRIPTION
### 🎨 Palette: Add Character Counter to Contact Form

#### 💡 What:
Implemented a real-time character counter for the "Message" field on the Contact page. The counter tracks the 5,000-character limit and provides visual feedback as the user approaches the maximum capacity.

#### 🎯 Why:
Large text fields without visible constraints can lead to "silent" truncation where a user submits a message only to find it was cut off. This enhancement provides proactive guidance and prevents user frustration.

#### ♿ Accessibility:
- **ARIA Integration:** Linked the counter to the textarea via `aria-describedby`.
- **Live Updates:** Used `aria-live="polite"` to ensure screen reader users receive updates about the remaining capacity without being interrupted while typing.
- **Semantic Feedback:** The "warning" state at 90% capacity uses the brand's high-contrast `accent` color (maroon) to signify urgency.

#### 📸 Verification:
- Verified that the counter starts at `0 / 5000`.
- Verified real-time updates as the user types.
- Verified the transition to `text-accent` color at 4,501 characters (90% threshold).
- Verified that the counter resets correctly when the form is cleared or submitted.
- Confirmed the production build (`pnpm build`) is successful and no temporary artifacts are included in the commit.

---
*PR created automatically by Jules for task [2776655720394208312](https://jules.google.com/task/2776655720394208312) started by @Twisted66*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time character counter added to the contact form message field with visual feedback when approaching the maximum character limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->