### PR TITLE
🎨 Palette: Add real-time character counter to contact form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-02-14 - Interactive Navigation Feedback and Component Extensibility
 **Learning:** Mobile menu toggles that don't change their icon (e.g., staying as a hamburger when open) fail to provide immediate visual confirmation of the menu state. Additionally, internal UI components like 'MagneticButton' must support attribute spreading to allow developers to inject critical accessibility attributes (like aria-label) without modifying the base component.
 **Action:** Ensure all toggle interactions have distinct visual states (icons/colors) and ensure all base UI components spread '...rest' props to their root interactive element.
+
+## 2026-02-14 - Real-time Character Constraints and Programmatic Syncing
+**Learning:** Textareas with character limits must feature a real-time counter linked via 'aria-describedby' and 'aria-live="polite"' to prevent silent data loss or submission errors. Crucially, counter initialization logic must handle programmatic value changes (e.g., pre-filling form fields via URL queries or browser restoration) to ensure the UI remains in sync with the actual input state.
+**Action:** Implement real-time counters with accessibility attributes for all length-limited textareas and always trigger a manual update on initialization to account for pre-filled values.

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -97,7 +97,12 @@ const messagePlaceholder =
                    Message <span class="text-accent">*</span>
                  </span>
                </label>
-               <textarea class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none" id="message" name="message" placeholder={messagePlaceholder} required aria-required="true"></textarea>
+               <textarea class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none" id="message" name="message" placeholder={messagePlaceholder} required aria-required="true" minlength="10" maxlength="5000" aria-describedby="message-counter"></textarea>
+               <div class="flex justify-end mt-2">
+                 <span id="message-counter" class="text-[10px] uppercase tracking-widest font-bold opacity-40 transition-colors duration-300" aria-live="polite">
+                   0 / 5000
+                 </span>
+               </div>
             </div>
 
             <div class="group">
@@ -330,6 +335,21 @@ const messagePlaceholder =
     const fileNameDisplay = document.getElementById('file-name');
     const roleFromQuery = form.dataset.role?.trim() ?? '';
 
+    const messageCounter = document.getElementById('message-counter');
+    const updateCounter = () => {
+      if (!(messageInput instanceof HTMLTextAreaElement) || !(messageCounter instanceof HTMLElement)) return;
+      const length = messageInput.value.length;
+      messageCounter.textContent = `${length} / 5000`;
+
+      if (length >= 4500) {
+        messageCounter.classList.remove('opacity-40');
+        messageCounter.classList.add('opacity-100', 'text-accent');
+      } else {
+        messageCounter.classList.add('opacity-40');
+        messageCounter.classList.remove('opacity-100', 'text-accent');
+      }
+    };
+
     const prefillCareerApplicationMessage = () => {
       if (!(subjectSelect instanceof HTMLSelectElement) || !(messageInput instanceof HTMLTextAreaElement)) return;
       if (subjectSelect.value !== 'careers' || !roleFromQuery || messageInput.value.trim()) return;
@@ -339,11 +359,17 @@ const messagePlaceholder =
         'Current location:\n' +
         'Availability:\n' +
         'CV/Portfolio link:\n';
+      updateCounter();
     };
 
     prefillCareerApplicationMessage();
     if (subjectSelect instanceof HTMLSelectElement) {
       subjectSelect.addEventListener('change', prefillCareerApplicationMessage);
+    }
+    if (messageInput instanceof HTMLTextAreaElement) {
+      messageInput.addEventListener('input', updateCounter);
+      // Initial update for non-career pre-fills or browser restores
+      updateCounter();
     }
 
     // Display selected file name


### PR DESCRIPTION
### 🎨 Palette: Add real-time character counter to contact form

#### 💡 What
Added a real-time character counter to the message textarea on the contact page (`src/pages/contact.astro`).

#### 🎯 Why
The backend enforces a 5,000-character limit. Without a frontend counter, users might unknowingly exceed the limit, leading to silent truncation or submission errors. This provides immediate feedback and guidance.

#### ♿ Accessibility & UX
- **Real-time feedback:** The counter updates as the user types.
- **Visual Cues:** The counter turns `text-accent` (reddish) when 90% of the limit (4,500 characters) is reached.
- **Screen Reader Support:** Linked via `aria-describedby` and uses `aria-live="polite"` for live updates.
- **Robustness:** Handles manual input, browser restoration, and programmatic pre-fills (e.g., career application templates) by triggering an initial sync on page load.
- **Semantic Validation:** Added `minlength="10"` and `maxlength="5000"` to the textarea.

#### 📸 Verification
- Verified with Playwright automation testing.
- Confirmed accessibility attributes and visual styling triggers via screenshots.
- Cleaned up development artifacts (dev logs/lockfiles) before submission.

---
*PR created automatically by Jules for task [13298110932018692636](https://jules.google.com/task/13298110932018692636) started by @Twisted66*