### PR TITLE
Add accessible character counter to contact form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-02-14 - Interactive Navigation Feedback and Component Extensibility
 **Learning:** Mobile menu toggles that don't change their icon (e.g., staying as a hamburger when open) fail to provide immediate visual confirmation of the menu state. Additionally, internal UI components like 'MagneticButton' must support attribute spreading to allow developers to inject critical accessibility attributes (like aria-label) without modifying the base component.
 **Action:** Ensure all toggle interactions have distinct visual states (icons/colors) and ensure all base UI components spread '...rest' props to their root interactive element.
+
+## 2026-02-14 - Real-time Character Constraints and Visual Feedback
+**Learning:** Textareas with character limits must feature a real-time counter linked via `aria-describedby` to ensure accessibility. Providing visual feedback, such as a color change (e.g., using the brand's accent color) when reaching 90% of the limit, significantly improves the user's ability to manage long inputs without trial-and-error. Programmatic value changes and form resets must also be explicitly handled to keep the UI counter in sync.
+**Action:** Always include an accessible character counter for limited textareas and use distinct styling for nearing-limit states.

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -97,7 +97,21 @@ const messagePlaceholder =
                    Message <span class="text-accent">*</span>
                  </span>
                </label>
-               <textarea class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none" id="message" name="message" placeholder={messagePlaceholder} required aria-required="true"></textarea>
+               <textarea
+                  class="form-input w-full bg-transparent border-b-2 border-primary/20 py-4 text-xl transition-all duration-300 placeholder-primary/30 resize-none h-32 focus-visible:border-accent focus-visible:outline-none"
+                  id="message"
+                  name="message"
+                  placeholder={messagePlaceholder}
+                  required
+                  aria-required="true"
+                  maxlength="5000"
+                  aria-describedby="message-counter"
+               ></textarea>
+               <div class="flex justify-end mt-2">
+                 <span id="message-counter" class="text-xs uppercase tracking-widest font-bold text-primary opacity-70 transition-colors duration-300" aria-hidden="false">
+                   0 / 5,000
+                 </span>
+               </div>
             </div>
 
             <div class="group">
@@ -326,9 +340,25 @@ const messagePlaceholder =
     const statusBox = document.getElementById('form-status');
     const subjectSelect = form.querySelector('#subject');
     const messageInput = form.querySelector('#message');
+    const messageCounter = document.getElementById('message-counter');
     const fileInput = document.querySelector('#attachment');
     const fileNameDisplay = document.getElementById('file-name');
     const roleFromQuery = form.dataset.role?.trim() ?? '';
+
+    const updateMessageCounter = () => {
+      if (!(messageInput instanceof HTMLTextAreaElement) || !(messageCounter instanceof HTMLElement)) return;
+      const count = messageInput.value.length;
+      const limit = 5000;
+      messageCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+      if (count >= limit * 0.9) {
+        messageCounter.classList.remove('text-primary', 'opacity-70');
+        messageCounter.classList.add('text-accent', 'opacity-100');
+      } else {
+        messageCounter.classList.add('text-primary', 'opacity-70');
+        messageCounter.classList.remove('text-accent', 'opacity-100');
+      }
+    };
 
     const prefillCareerApplicationMessage = () => {
       if (!(subjectSelect instanceof HTMLSelectElement) || !(messageInput instanceof HTMLTextAreaElement)) return;
@@ -339,12 +369,23 @@ const messagePlaceholder =
         'Current location:\n' +
         'Availability:\n' +
         'CV/Portfolio link:\n';
+      updateMessageCounter();
     };
 
     prefillCareerApplicationMessage();
+    updateMessageCounter();
+
     if (subjectSelect instanceof HTMLSelectElement) {
       subjectSelect.addEventListener('change', prefillCareerApplicationMessage);
     }
+
+    if (messageInput instanceof HTMLTextAreaElement) {
+      messageInput.addEventListener('input', updateMessageCounter);
+    }
+
+    form.addEventListener('reset', () => {
+      setTimeout(updateMessageCounter, 0);
+    });
 
     // Display selected file name
     if (fileInput instanceof HTMLInputElement && fileNameDisplay) {


### PR DESCRIPTION
I have implemented a real-time, accessible character counter for the contact form's message field. This provides immediate feedback to users as they approach the 5,000-character limit, preventing submission errors and improving the overall input experience. The counter features brand-consistent styling and includes a high-visibility state (using the accent color) when the input exceeds 90% of the capacity. Accessibility is ensured via `aria-describedby` and explicit handling of form resets and programmatic updates.

---
*PR created automatically by Jules for task [240693613896460962](https://jules.google.com/task/240693613896460962) started by @Twisted66*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact page message textarea now includes a live character counter (0/5,000) with visual feedback when approaching the limit
  * Enhanced accessibility support for character counter information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->