### PR TITLE
🎨 Palette: Character counter for careers-admin description

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2026-02-14 - Real-time Character Constraints and Visual Feedback
 **Learning:** Textareas with character limits must feature a real-time counter linked via `aria-describedby` to ensure accessibility. Providing visual feedback, such as a color change (e.g., using the brand's accent color) when reaching 90% of the limit, significantly improves the user's ability to manage long inputs without trial-and-error. Programmatic value changes and form resets must also be explicitly handled to keep the UI counter in sync.
 **Action:** Always include an accessible character counter for limited textareas and use distinct styling for nearing-limit states.
+
+## 2026-03-26 - Unified Character Counters for Large Inputs
+**Learning:** For admin panels and public forms with significant text inputs (e.g., job descriptions, project messages), real-time character counters linked via `aria-describedby` are critical for both UX and accessibility. Providing a visual threshold warning (e.g., at 90% capacity) using the brand's accent color prevents user frustration when nearing technical limits. Consistency across the application (e.g., `contact.astro` and `careers-admin.astro`) reinforces the design system's predictability.
+**Action:** Implement real-time character counters for all textareas with `maxlength` constraints, using the 90% threshold for visual feedback and ensuring sync on input and reset events.

--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end mt-1">
+              <span id="description-counter" class="text-[10px] uppercase tracking-widest font-bold opacity-60 transition-colors duration-300" aria-hidden="false">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -168,6 +174,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const rolesCountElement = document.getElementById('open-roles-count');
   const submitButton = document.getElementById('create-job-submit');
   const refreshButton = document.getElementById('refresh-jobs');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
 
   const base = typeof jobsApiBaseUrl === 'string' ? jobsApiBaseUrl.trim().replace(/\/$/, '') : '';
   const endpoint = base ? `${base}/api/jobs` : '/api/jobs';
@@ -185,6 +193,31 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
   }
+
+  function updateDescriptionCounter() {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('opacity-60');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.add('opacity-60');
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
+    }
+  }
+
+  if (descriptionInput instanceof HTMLTextAreaElement) {
+    descriptionInput.addEventListener('input', updateDescriptionCounter);
+  }
+
+  form?.addEventListener('reset', () => {
+    setTimeout(updateDescriptionCounter, 0);
+  });
+
+  updateDescriptionCounter();
 
   function escapeHtml(value) {
     return String(value)


### PR DESCRIPTION
I have implemented a micro-UX improvement for the `careers-admin` page:

- **💡 What:** Added a real-time character counter to the Job Description textarea.
- **🎯 Why:** Users need to know how much space they have left when drafting long job descriptions (5,000 character limit). This prevents frustration upon form submission.
- **♿ Accessibility:** The counter is linked to the textarea using `aria-describedby`, ensuring screen readers can announce the character limit status.
- **✨ Polish:** Added a visual threshold warning that changes the counter's color to the brand's accent color when the user reaches 90% (4,500 characters) of the limit.
- **🛠️ Robustness:** The counter is automatically synchronized on page load, during typing, and upon form resets.

I verified the functionality with a Playwright test and ensured the repository is clean of any build or test artifacts before submission.

---
*PR created automatically by Jules for task [6704770991287777012](https://jules.google.com/task/6704770991287777012) started by @Twisted66*