### PR TITLE
🎨 Palette: Add character counter to careers admin description

### DIFF
--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end mt-2">
+              <span id="description-counter" class="text-xs uppercase tracking-widest font-bold text-primary opacity-70 transition-colors duration-300">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -168,6 +174,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const rolesCountElement = document.getElementById('open-roles-count');
   const submitButton = document.getElementById('create-job-submit');
   const refreshButton = document.getElementById('refresh-jobs');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
 
   const base = typeof jobsApiBaseUrl === 'string' ? jobsApiBaseUrl.trim().replace(/\/$/, '') : '';
   const endpoint = base ? `${base}/api/jobs` : '/api/jobs';
@@ -178,6 +186,21 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
     statusElement.textContent = message;
     statusElement.classList.toggle('text-red-600', isError);
     statusElement.classList.toggle('text-emerald-700', !isError);
+  }
+
+  function updateDescriptionCounter() {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('text-primary', 'opacity-70');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.add('text-primary', 'opacity-70');
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
+    }
   }
 
   function toIsoFromLocalDateTime(value) {
@@ -308,6 +331,16 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
       apiKeyInput.value = savedApiKey;
     }
   }
+
+  updateDescriptionCounter();
+
+  if (descriptionInput instanceof HTMLTextAreaElement) {
+    descriptionInput.addEventListener('input', updateDescriptionCounter);
+  }
+
+  form?.addEventListener('reset', () => {
+    setTimeout(updateDescriptionCounter, 0);
+  });
 
   form?.addEventListener('submit', async (event) => {
     event.preventDefault();

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,36 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Careers Admin description counter updates on input', async ({ page }: { page: Page }) => {
+    await page.goto('/careers-admin');
+
+    // Wait for Astro scripts
+    await page.waitForTimeout(500);
+
+    const textarea = page.locator('#description');
+    const counter = page.locator('#description-counter');
+
+    // Initial state
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+
+    // Type some text
+    await textarea.fill('Test description for the new career role.');
+    const count = 'Test description for the new career role.'.length;
+    await expect(counter).toHaveText(`${count} / 5,000`);
+
+    // Test threshold (90% of 5,000 = 4,500)
+    const longText = 'A'.repeat(4500);
+    await textarea.fill(longText);
+    await expect(counter).toHaveText('4,500 / 5,000');
+    await expect(counter).toHaveClass(/text-accent/);
+
+    // Test reset
+    await page.locator('#create-job-form').evaluate((form: HTMLFormElement) => form.reset());
+    // reset has a setTimeout(..., 0) in the script
+    await page.waitForTimeout(100);
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+  });
 });


### PR DESCRIPTION
Implemented a micro-UX improvement in `src/pages/careers-admin.astro` by adding a real-time character counter to the role description field. This change enhances user feedback and accessibility, aligning with the project's design standards established in the contact form.

Key changes:
- Added a `description-counter` element linked via `aria-describedby`.
- Implemented client-side logic to update the count on input and form reset.
- Added visual styling to highlight when the user is nearing the 5,000-character limit (at 90% capacity).
- Added comprehensive Playwright tests in `tests/ux-verification.spec.ts` to ensure the counter works correctly across different input states.

---
*PR created automatically by Jules for task [12369500294006796153](https://jules.google.com/task/12369500294006796153) started by @Twisted66*