### PR TITLE
🎨 Palette: Add real-time character counter to Careers Admin

### DIFF
--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end mt-1">
+              <span id="description-counter" class="text-[10px] uppercase tracking-widest font-bold text-primary opacity-60 transition-colors duration-300" aria-hidden="false">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -168,6 +174,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const rolesCountElement = document.getElementById('open-roles-count');
   const submitButton = document.getElementById('create-job-submit');
   const refreshButton = document.getElementById('refresh-jobs');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
 
   const base = typeof jobsApiBaseUrl === 'string' ? jobsApiBaseUrl.trim().replace(/\/$/, '') : '';
   const endpoint = base ? `${base}/api/jobs` : '/api/jobs';
@@ -178,6 +186,21 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
     statusElement.textContent = message;
     statusElement.classList.toggle('text-red-600', isError);
     statusElement.classList.toggle('text-emerald-700', !isError);
+  }
+
+  function updateDescriptionCounter() {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('opacity-60');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
+      descriptionCounter.classList.add('opacity-60');
+    }
   }
 
   function toIsoFromLocalDateTime(value) {
@@ -309,6 +332,10 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
     }
   }
 
+  descriptionInput?.addEventListener('input', updateDescriptionCounter);
+  form?.addEventListener('reset', () => setTimeout(updateDescriptionCounter, 0));
+  updateDescriptionCounter();
+
   form?.addEventListener('submit', async (event) => {
     event.preventDefault();
     if (!(form instanceof HTMLFormElement)) return;
@@ -349,6 +376,7 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
 
       rememberJobsApiKey(apiKey);
       form.reset();
+      updateDescriptionCounter();
       if (apiKeyInput instanceof HTMLInputElement) apiKeyInput.value = apiKey;
       if (postedAtInput instanceof HTMLInputElement) postedAtInput.value = '';
 

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,32 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Careers Admin character counter updates and warns at threshold', async ({ page }: { page: Page }) => {
+    await page.goto('/careers-admin');
+
+    const textarea = page.locator('#description');
+    const counter = page.locator('#description-counter');
+
+    // Initially 0 / 5,000
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+
+    // Type some text
+    await textarea.fill('This is a test description for the careers admin page.');
+    await expect(counter).toHaveText('54 / 5,000');
+
+    // Reach 90% threshold (4500 characters)
+    const longText = 'a'.repeat(4500);
+    await textarea.fill(longText);
+    await expect(counter).toHaveText('4,500 / 5,000');
+    await expect(counter).toHaveClass(/text-accent/);
+
+    // Reset form and check counter
+    await page.locator('#create-job-form').evaluate((form: HTMLFormElement) => form.reset());
+    // Use a small timeout to allow for the reset event handler to run
+    await page.waitForTimeout(50);
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+  });
 });


### PR DESCRIPTION
This PR adds a micro-UX improvement to the Careers Admin panel by implementing a real-time character counter for the job description textarea.

### 💡 What: 
Added an accessible, real-time character counter below the 'Description' field in `src/pages/careers-admin.astro`.

### 🎯 Why: 
The textarea has a 5,000-character limit enforced by the backend, but users had no way of knowing their current count or how close they were to the limit until attempting to submit.

### ♿ Accessibility:
- Linked via `aria-describedby` for screen reader awareness.
- Uses `toLocaleString()` for accessible number formatting.
- Maintains visual contrast even when the 'accent' color warning is triggered.

### ✅ Verification:
- Added a new Playwright test in `tests/ux-verification.spec.ts` covering initial state, typing, threshold warning, and form reset.
- Manually verified via frontend verification scripts (screenshots/video attached in workflow).

---
*PR created automatically by Jules for task [980075023954886663](https://jules.google.com/task/980075023954886663) started by @Twisted66*