### PR TITLE
🎨 Palette: Add accessible character counter to Careers Admin description

### DIFF
--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end mt-1">
+              <span id="description-counter" class="text-[10px] uppercase tracking-widest font-bold opacity-60 transition-colors duration-300">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -168,6 +174,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const rolesCountElement = document.getElementById('open-roles-count');
   const submitButton = document.getElementById('create-job-submit');
   const refreshButton = document.getElementById('refresh-jobs');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
 
   const base = typeof jobsApiBaseUrl === 'string' ? jobsApiBaseUrl.trim().replace(/\/$/, '') : '';
   const endpoint = base ? `${base}/api/jobs` : '/api/jobs';
@@ -205,6 +213,21 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   function rememberJobsApiKey(apiKey) {
     if (apiKey) {
       sessionStorage.setItem(API_KEY_STORAGE_KEY, apiKey);
+    }
+  }
+
+  function updateDescriptionCounter() {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('opacity-60');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.add('opacity-60');
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
     }
   }
 
@@ -308,6 +331,16 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
       apiKeyInput.value = savedApiKey;
     }
   }
+
+  if (descriptionInput instanceof HTMLTextAreaElement) {
+    descriptionInput.addEventListener('input', updateDescriptionCounter);
+  }
+
+  form?.addEventListener('reset', () => {
+    setTimeout(updateDescriptionCounter, 0);
+  });
+
+  updateDescriptionCounter();
 
   form?.addEventListener('submit', async (event) => {
     event.preventDefault();

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,37 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Careers Admin character counter updates on input', async ({ page }: { page: Page }) => {
+    await page.goto('/careers-admin');
+
+    const textarea = page.locator('#description');
+    const counter = page.locator('#description-counter');
+
+    // Initial state
+    await expect(counter).toHaveText('0 / 5,000');
+
+    // Type some text
+    await textarea.fill('Testing character counter');
+    await expect(counter).toHaveText('25 / 5,000');
+
+    // Check threshold styling (90% of 5000 is 4500)
+    // We can simulate a long string
+    const longText = 'a'.repeat(4501);
+    await textarea.fill(longText);
+    await expect(counter).toHaveText('4,501 / 5,000');
+    await expect(counter).toHaveClass(/text-accent/);
+
+    // Reset form and check counter reset
+    await page.click('#create-job-form button[type="button"]:has-text("Refresh")'); // This is not reset button
+    // Actually there is no reset button in the UI, but we can call form.reset() via evaluate
+    await page.evaluate(() => {
+      const form = document.getElementById('create-job-form') as HTMLFormElement;
+      if (form) form.reset();
+    });
+
+    // Resetting form via script triggers counter update after a timeout
+    await page.waitForTimeout(100);
+    await expect(counter).toHaveText('0 / 5,000');
+  });
 });


### PR DESCRIPTION
### 🎨 Palette: Add character counter to careers admin

#### 💡 What: 
Added an accessible, real-time character counter to the job description textarea on the Careers Admin page.

#### 🎯 Why: 
The description field has a strict 5,000-character limit. Providing a counter helps HR staff manage long job descriptions without trial-and-error upon submission.

#### ♿ Accessibility:
- Linked the counter to the textarea using `aria-describedby`.
- Used `toLocaleString()` for accessible number formatting.
- Added visual feedback (brand accent color) when reaching 90% of the limit.

#### ✅ Verification:
- Added a new Playwright test in `tests/ux-verification.spec.ts` to validate counter updates and styling thresholds.
- Manually verified via Playwright screenshot/video recording.
- Verified build integrity with `pnpm build`.

---
*PR created automatically by Jules for task [11616055067836031545](https://jules.google.com/task/11616055067836031545) started by @Twisted66*