### PR TITLE
🎨 Palette: Implement functional hero scroll indicator

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2026-02-14 - Real-time Character Constraints and Visual Feedback
 **Learning:** Textareas with character limits must feature a real-time counter linked via `aria-describedby` to ensure accessibility. Providing visual feedback, such as a color change (e.g., using the brand's accent color) when reaching 90% of the limit, significantly improves the user's ability to manage long inputs without trial-and-error. Programmatic value changes and form resets must also be explicitly handled to keep the UI counter in sync.
 **Action:** Always include an accessible character counter for limited textareas and use distinct styling for nearing-limit states.
+
+## 2026-02-14 - Functional Scroll Indicators and Responsive Scroll Padding
+**Learning:** Purely decorative scroll indicators are a missed UX opportunity. Converting them into functional anchor links with proper ARIA labels improves navigation efficiency. Furthermore, using responsive Tailwind `scroll-mt` classes that match sticky header heights across different breakpoints ensures that target sections are never obscured upon navigation.
+**Action:** Always implement visual scroll cues as functional anchor links and apply matching responsive `scroll-mt` padding to target sections.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,17 +93,17 @@ const structuredData = {
       </div>
 
       <!-- Scroll Down Indicator -->
-      <div class="absolute bottom-6 sm:bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-white/60 animate-bounce home-scroll-indicator">
+      <a href="#intro" aria-label="Scroll to introduction" class="absolute bottom-6 sm:bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-white/60 hover:text-white transition-colors animate-bounce home-scroll-indicator focus-visible:outline-accent focus-visible:outline-offset-4">
         <span class="text-[10px] uppercase tracking-[0.3em]">Scroll</span>
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path d="M19 14l-7 7m0 0l-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
         </svg>
-      </div>
+      </a>
     </div>
   </section>
 
   <!-- Intro Section - 4-column grid -->
-  <section class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 border-b border-border">
+  <section id="intro" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 border-b border-border scroll-mt-[64px] sm:scroll-mt-[72px] xl:scroll-mt-[104px]">
     <div class="p-8 lg:border-r border-b lg:border-b-0 border-border">
       <h2 class="font-bold text-lg mb-4 uppercase">Delivering iconic projects<br/>in partnership with our<br/>clients around the world</h2>
       <a class="inline-flex items-center gap-2 text-sm mt-8 group" href="/about">

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,21 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Hero scroll indicator is a functional link', async ({ page }: { page: Page }) => {
+    await page.goto('/');
+
+    const scrollIndicator = page.locator('a[href="#intro"]');
+
+    // Verify link exists and has correct attributes
+    await expect(scrollIndicator).toBeVisible();
+    await expect(scrollIndicator).toHaveAttribute('aria-label', 'Scroll to introduction');
+
+    // Verify target exists
+    const targetSection = page.locator('section#intro');
+    await expect(targetSection).toBeVisible();
+
+    // Verify target has scroll-mt classes (representative check)
+    await expect(targetSection).toHaveClass(/scroll-mt-\[64px\]/);
+  });
 });


### PR DESCRIPTION
I've implemented a micro-UX improvement on the homepage by making the hero's scroll indicator functional.

### 💡 What:
- Converted the non-functional "Scroll" indicator into an anchor link (`<a>`) pointing to the introductory section.
- Added a target `id="intro"` to the first section after the hero.
- Added responsive `scroll-mt` classes to ensure perfect alignment below the sticky header (matching its 64px/72px/104px heights).

### 🎯 Why:
- Improves navigation efficiency for users who expect the "Scroll" prompt to be interactive.
- Enhances accessibility by providing a clear skip-link-like behavior to the main content.

### ♿ Accessibility:
- Added `aria-label="Scroll to introduction"` to the link.
- Implemented `focus-visible` styles with the brand's accent color and offset for high visibility during keyboard navigation.

### ✅ Verification:
- Added a Playwright test in `tests/ux-verification.spec.ts` that verifies the link's existence, attributes, and its target's scroll padding.
- Verified manually via a recorded Playwright session (all tests passed).
- Ensured no build artifacts or temporary files are included in this PR.

---
*PR created automatically by Jules for task [11433193966879176955](https://jules.google.com/task/11433193966879176955) started by @Twisted66*