### PR TITLE
🎨 Palette: Add accessible character counter to Careers Admin

### DIFF
--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end">
+              <span id="description-counter" class="text-[10px] uppercase tracking-widest font-bold opacity-60 transition-colors duration-300">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -163,6 +169,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const form = document.getElementById('create-job-form');
   const apiKeyInput = document.getElementById('jobs-api-key');
   const postedAtInput = document.getElementById('postedAt');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
   const statusElement = document.getElementById('admin-status');
   const listElement = document.getElementById('open-roles-list');
   const rolesCountElement = document.getElementById('open-roles-count');
@@ -207,6 +215,26 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
       sessionStorage.setItem(API_KEY_STORAGE_KEY, apiKey);
     }
   }
+
+  function updateDescriptionCounter() {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('opacity-60');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.add('opacity-60');
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
+    }
+  }
+
+  descriptionInput?.addEventListener('input', updateDescriptionCounter);
+  form?.addEventListener('reset', () => {
+    setTimeout(updateDescriptionCounter, 0);
+  });
 
   async function sendRequest(url, options = {}) {
     const response = await fetch(url, {
@@ -349,6 +377,7 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
 
       rememberJobsApiKey(apiKey);
       form.reset();
+      updateDescriptionCounter();
       if (apiKeyInput instanceof HTMLInputElement) apiKeyInput.value = apiKey;
       if (postedAtInput instanceof HTMLInputElement) postedAtInput.value = '';
 

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,37 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Careers Admin character counter works', async ({ page }: { page: Page }) => {
+    await page.goto('/careers-admin');
+
+    const textarea = page.locator('textarea#description');
+    const counter = page.locator('#description-counter');
+
+    // Initial state
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+
+    // Type some text
+    await textarea.fill('Short text');
+    await expect(counter).toHaveText('10 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+
+    // Fill to > 90% (4500 characters)
+    const longText = 'a'.repeat(4501);
+    await textarea.fill(longText);
+    await expect(counter).toHaveText('4,501 / 5,000');
+    await expect(counter).toHaveClass(/text-accent/);
+
+    // Reset form
+    await page.locator('button#refresh-jobs').focus(); // Just to move focus
+    await page.evaluate(() => {
+      (document.getElementById('create-job-form') as HTMLFormElement).reset();
+    });
+
+    // Wait for the setTimeout in the reset listener
+    await page.waitForTimeout(100);
+    await expect(counter).toHaveText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+  });
 });


### PR DESCRIPTION
### 💡 What:
Implemented a real-time, accessible character counter for the `description` textarea in the `careers-admin.astro` page.

### 🎯 Why:
The job description field has a 5,000-character limit, but users previously had no way of knowing their current count until they attempted to submit. This addition provides immediate feedback and prevents submission errors.

### ♿ Accessibility:
- Used `aria-describedby` to link the counter to the textarea for screen readers.
- Added a high-contrast visual warning (brand accent color) when the user reaches 90% of the character limit.
- Used `toLocaleString()` for accessible number formatting.

### ✅ Verification:
- Added a new Playwright test in `tests/ux-verification.spec.ts` that validates the counter updates and reset behavior.
- Verified project integrity with `pnpm build` and `pnpm run astro -- check`.

---
*PR created automatically by Jules for task [6558982604169141151](https://jules.google.com/task/6558982604169141151) started by @Twisted66*