### PR TITLE
🎨 Palette: Add character counter to Careers Admin description

### DIFF
--- a/src/pages/careers-admin.astro
+++ b/src/pages/careers-admin.astro
@@ -125,7 +125,13 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
               maxlength="5000"
               class="w-full bg-background border border-primary/20 px-4 py-3 text-sm resize-y"
               placeholder="Describe responsibilities, required experience, and qualifications."
+              aria-describedby="description-counter"
             ></textarea>
+            <div class="flex justify-end mt-1">
+              <span id="description-counter" class="text-[10px] uppercase tracking-widest font-bold opacity-70 transition-colors duration-300">
+                0 / 5,000
+              </span>
+            </div>
           </div>
 
           <div class="flex flex-wrap items-center gap-4">
@@ -163,6 +169,8 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
   const form = document.getElementById('create-job-form');
   const apiKeyInput = document.getElementById('jobs-api-key');
   const postedAtInput = document.getElementById('postedAt');
+  const descriptionInput = document.getElementById('description');
+  const descriptionCounter = document.getElementById('description-counter');
   const statusElement = document.getElementById('admin-status');
   const listElement = document.getElementById('open-roles-list');
   const rolesCountElement = document.getElementById('open-roles-count');
@@ -302,12 +310,37 @@ const jobsApiBaseUrl = import.meta.env.PUBLIC_JOBS_API_BASE_URL?.trim() ?? '';
     }
   }
 
+  const updateDescriptionCounter = () => {
+    if (!(descriptionInput instanceof HTMLTextAreaElement) || !(descriptionCounter instanceof HTMLElement)) return;
+    const count = descriptionInput.value.length;
+    const limit = 5000;
+    descriptionCounter.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    if (count >= limit * 0.9) {
+      descriptionCounter.classList.remove('opacity-70');
+      descriptionCounter.classList.add('text-accent', 'opacity-100');
+    } else {
+      descriptionCounter.classList.add('opacity-70');
+      descriptionCounter.classList.remove('text-accent', 'opacity-100');
+    }
+  };
+
+  if (descriptionInput instanceof HTMLTextAreaElement) {
+    descriptionInput.addEventListener('input', updateDescriptionCounter);
+  }
+
+  updateDescriptionCounter();
+
   if (apiKeyInput instanceof HTMLInputElement) {
     const savedApiKey = sessionStorage.getItem(API_KEY_STORAGE_KEY);
     if (savedApiKey) {
       apiKeyInput.value = savedApiKey;
     }
   }
+
+  form?.addEventListener('reset', () => {
+    setTimeout(updateDescriptionCounter, 0);
+  });
 
   form?.addEventListener('submit', async (event) => {
     event.preventDefault();

--- a/tests/ux-verification.spec.ts
+++ b/tests/ux-verification.spec.ts
@@ -54,4 +54,32 @@ test.describe('UX Improvements Verification', () => {
     // Check for other spread props like type="submit"
     await expect(submitButton).toHaveAttribute('type', 'submit');
   });
+
+  test('Careers Admin character counter works', async ({ page }: { page: Page }) => {
+    await page.goto('/careers-admin');
+
+    const textarea = page.locator('textarea#description');
+    const counter = page.locator('#description-counter');
+
+    // Initially should be 0
+    await expect(counter).toContainText('0 / 5,000');
+
+    // Type some text
+    await textarea.fill('This is a test description with more than twenty characters.');
+    const count = (await textarea.inputValue()).length;
+    await expect(counter).toContainText(`${count} / 5,000`);
+
+    // Verify threshold styling (90% of 5000 is 4500)
+    const longText = 'a'.repeat(4501);
+    await textarea.fill(longText);
+    await expect(counter).toHaveClass(/text-accent/);
+    await expect(counter).toContainText('4,501 / 5,000');
+
+    // Verify reset
+    await page.locator('#create-job-form').evaluate((form: HTMLFormElement) => form.reset());
+    // Wait for the setTimeout(..., 0) in the reset handler
+    await page.waitForTimeout(100);
+    await expect(counter).toContainText('0 / 5,000');
+    await expect(counter).not.toHaveClass(/text-accent/);
+  });
 });


### PR DESCRIPTION
This PR enhances the Careers Admin page by adding a real-time character counter to the "Description" textarea. This improvement provides immediate feedback to HR staff on their input length, preventing submission errors due to character limit violations (5,000 characters). 

Key features:
- **Real-time feedback**: Updates as you type.
- **Accessibility**: Correctly uses `aria-describedby` to link the counter to the textarea.
- **Visual Warning**: The counter changes color to the brand accent when reaching 90% capacity (4,500 characters).
- **Automated Verification**: Added a new test case to `tests/ux-verification.spec.ts` to ensure the logic remains robust.
- **Standard Compliant**: Reuses existing Tailwind classes and follows the repository's micro-UX pattern.

---
*PR created automatically by Jules for task [10090481799562875480](https://jules.google.com/task/10090481799562875480) started by @Twisted66*