### PR TITLE
🎨 Palette: fix mobile menu accessibility

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -124,7 +124,7 @@ const isActive = (href: string) => {
     const setBackgroundInert = (isOpen: boolean) => {
       if (!siteHeader) return;
       Array.from(document.body.children).forEach((element) => {
-        if (element === siteHeader) return;
+        if (element.contains(siteHeader)) return;
         if (isOpen) {
           element.setAttribute('inert', '');
           element.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
Fixed a critical accessibility bug where the mobile menu became non-interactive once opened. The original logic used a strict equality check to prevent the header from being marked as 'inert', which failed when the header was nested inside a wrapper. Updated the check to use '.contains(siteHeader)' for robust background isolation. Verified with existing Playwright tests and manual frontend verification.

---
*PR created automatically by Jules for task [9269562340114418460](https://jules.google.com/task/9269562340114418460) started by @Twisted66*